### PR TITLE
reset $this->frameSources array in the reset() method

### DIFF
--- a/src/GifCreator/GifCreator.php
+++ b/src/GifCreator/GifCreator.php
@@ -334,7 +334,7 @@ class GifCreator
      */
     public function reset()
     {
-        $this->frameSources;
+        $this->frameSources=array();
         $this->gif = 'GIF89a'; // the GIF header
         $this->imgBuilt = false;
         $this->loop = 0;


### PR DESCRIPTION
Allow method chainig in classes using GifCreator with no need to recreate GifCreator object.
